### PR TITLE
 Update pull request commands to include target branch option

### DIFF
--- a/apps/SKonsole/Program.cs
+++ b/apps/SKonsole/Program.cs
@@ -68,11 +68,19 @@ var commitArgument = new Argument<string>
 rootCommand.Add(commitArgument);
 commitCommand.Add(commitArgument);
 
+var targetBranchOption = new Option<string>(
+       new string[] { "--targetBranch", "-t" },
+          () => { return "origin/main"; },
+             "The target branch for the pull request.");
+prCommand.AddOption(targetBranchOption);
+prDescriptionCommand.AddOption(targetBranchOption);
+prFeedbackCommand.AddOption(targetBranchOption);
+
 rootCommand.SetHandler(async (commitArgumentValue) => await RunCommitMessage(_kernel, _logger, commitArgumentValue), commitArgument);
 commitCommand.SetHandler(async (commitArgumentValue) => await RunCommitMessage(_kernel, _logger, commitArgumentValue), commitArgument);
-prCommand.SetHandler(async () => await RunPullRequestDescription(_kernel, _logger));
-prFeedbackCommand.SetHandler(async () => await RunPullRequestFeedback(_kernel, _logger));
-prDescriptionCommand.SetHandler(async () => await RunPullRequestDescription(_kernel, _logger));
+prCommand.SetHandler(async (targetBranch) => await RunPullRequestDescription(_kernel, _logger, targetBranch), targetBranchOption);
+prFeedbackCommand.SetHandler(async (targetBranch) => await RunPullRequestFeedback(_kernel, _logger, targetBranch), targetBranchOption);
+prDescriptionCommand.SetHandler(async (targetBranch) => await RunPullRequestDescription(_kernel, _logger, targetBranch), targetBranchOption);
 plannerCommand.SetHandler(async (messageArgumentValue) => await RunCreatePlan(_kernel, _logger, messageArgumentValue), messageArgument);
 promptChatCommand.SetHandler(async () => await RunPromptChat(_kernel, _logger));
 
@@ -152,14 +160,14 @@ static async Task RunCommitMessage(IKernel kernel, ILogger? logger, string commi
     (logger ?? kernel.Logger).LogInformation("Commit Message:\n{result}", kernelResponse.Result);
 }
 
-static async Task RunPullRequestDescription(IKernel kernel, ILogger? logger)
+static async Task RunPullRequestDescription(IKernel kernel, ILogger? logger, string targetBranch = "origin/main")
 {
     var process = new Process
     {
         StartInfo = new ProcessStartInfo
         {
             FileName = "git",
-            Arguments = "show --ignore-space-change origin/main..HEAD",
+            Arguments = $"show --ignore-space-change {targetBranch}..HEAD",
             RedirectStandardOutput = true,
             UseShellExecute = false,
             CreateNoWindow = true,
@@ -175,14 +183,14 @@ static async Task RunPullRequestDescription(IKernel kernel, ILogger? logger)
     (logger ?? kernel.Logger).LogInformation("Pull Request Description:\n{result}", kernelResponse.Result);
 }
 
-static async Task RunPullRequestFeedback(IKernel kernel, ILogger? logger)
+static async Task RunPullRequestFeedback(IKernel kernel, ILogger? logger, string targetBranch = "origin/main")
 {
     var process = new Process
     {
         StartInfo = new ProcessStartInfo
         {
             FileName = "git",
-            Arguments = "show --ignore-space-change origin/main..HEAD",
+            Arguments = $"show --ignore-space-change {targetBranch}..HEAD",
             RedirectStandardOutput = true,
             UseShellExecute = false,
             CreateNoWindow = true,


### PR DESCRIPTION
Summary:
This pull request updates the pull request commands in the SKonsole application to include a target branch option. The target branch option allows users to specify the branch to which the pull request should be made. By default, the target branch is set to "origin/main". This update improves the flexibility and usability of the pull request functionality.

Changes Made:
- Added a targetBranchOption to the pull request commands.
- The targetBranchOption allows users to specify the target branch for the pull request.
- The default value for the target branch is set to "origin/main".
- Updated the prCommand, prFeedbackCommand, and prDescriptionCommand handlers to include the targetBranchOption.
- Updated the RunPullRequestDescription and RunPullRequestFeedback methods to accept the targetBranch parameter.
- Modified the git show command arguments in the RunPullRequestDescription and RunPullRequestFeedback methods to use the target branch specified by the user.
- The RunPullRequestDescription and RunPullRequestFeedback methods now display the pull request description and feedback, respectively, based on the target branch specified by the user.

These changes enhance the pull request functionality by allowing users to specify the target branch for their pull requests, providing more control and flexibility in the pull request process.