### PR TITLE
Update PRCommand, PullRequestSkill, and PullRequestDescriptionGenerator

### DIFF
--- a/apps/SKonsole/Commands/PRCommand.cs
+++ b/apps/SKonsole/Commands/PRCommand.cs
@@ -3,7 +3,6 @@ using System.CommandLine.Invocation;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel.Orchestration;
-using Microsoft.SemanticKernel.TemplateEngine.Prompt;
 using SKonsole.Utils;
 
 namespace SKonsole.Commands;

--- a/skills/PRSkill/PullRequestSkill.cs
+++ b/skills/PRSkill/PullRequestSkill.cs
@@ -9,6 +9,8 @@ using Microsoft.SemanticKernel.SkillDefinition;
 using CondenseSkillLib;
 using Microsoft.SemanticKernel.AI.TextCompletion;
 using System.ComponentModel;
+using System.Net.WebSockets;
+using System.Text.Json.Nodes;
 
 namespace PRSkill;
 
@@ -147,9 +149,10 @@ public class PullRequestSkill
     {
         var prGenerator = context.Skills.GetFunction(SEMANTIC_FUNCTION_PATH, "PullRequestDescriptionGenerator");
 
-
         var prGeneratorCapture = this._kernel.Skills.GetFunction(SEMANTIC_FUNCTION_PATH, "PullRequestDescriptionGenerator");
-        var prompt = (await prGeneratorCapture.InvokeAsync()).Result;
+        var contextVariablesWithoutInput = context.Variables.Clone();
+        contextVariablesWithoutInput.Set("input", "");
+        var prompt = (await prGeneratorCapture.InvokeAsync(contextVariablesWithoutInput)).Result;
 
         var chunkedInput = CommitChunker.ChunkCommitInfo(input, CHUNK_SIZE);
         return await prGenerator.CondenseChunkProcess(this.condenseSkill, chunkedInput, prompt, context, "PullRequestDescriptionResult");

--- a/skills/PRSkill/SemanticFunctions/PRSkill/PullRequestDescriptionGenerator/config.json
+++ b/skills/PRSkill/SemanticFunctions/PRSkill/PullRequestDescriptionGenerator/config.json
@@ -17,9 +17,9 @@
         "description": "Part or all of a git diff or git show file output."
       },
       {
-        "name": "outputJson",
-        "default": "false",
-        "description": "Output the result as JSON."
+        "name": "outputFormatInstructions",
+        "default": "",
+        "description": "Instructions for formatting output if different from plain text."
       }
     ]
   }

--- a/skills/PRSkill/SemanticFunctions/PRSkill/PullRequestDescriptionGenerator/config.json
+++ b/skills/PRSkill/SemanticFunctions/PRSkill/PullRequestDescriptionGenerator/config.json
@@ -15,6 +15,11 @@
         "name": "input",
         "default": "",
         "description": "Part or all of a git diff or git show file output."
+      },
+      {
+        "name": "outputJson",
+        "default": "false",
+        "description": "Output the result as JSON."
       }
     ]
   }

--- a/skills/PRSkill/SemanticFunctions/PRSkill/PullRequestDescriptionGenerator/skprompt.txt
+++ b/skills/PRSkill/SemanticFunctions/PRSkill/PullRequestDescriptionGenerator/skprompt.txt
@@ -16,11 +16,6 @@ To complete this task, review the changes made in [GITDIFFCONTENT] and use this 
 Then, write a summary of the changes made, highlighting the key points and the most important changes.
 Finally, create a detailed list of specific changes, including any relevant details or context, and be sure to focus on the most important and relevant changes while avoiding unnecessary or redundant information.
 
-Output the result as json with fields for Title, Summary, and a list of Changes. 
-For example, result:
-{"Title": "My Title", "Summary": "My Summary", "Changes": ["Change 1", "Change 2"]}
-Otherwise return the result as a string WITHOUT formatting it in JSON.
-
-OUTPUT_JSON: {{$outputJson}}
+{{$outputFormatInstructions}}
 
 Result:

--- a/skills/PRSkill/SemanticFunctions/PRSkill/PullRequestDescriptionGenerator/skprompt.txt
+++ b/skills/PRSkill/SemanticFunctions/PRSkill/PullRequestDescriptionGenerator/skprompt.txt
@@ -16,8 +16,11 @@ To complete this task, review the changes made in [GITDIFFCONTENT] and use this 
 Then, write a summary of the changes made, highlighting the key points and the most important changes.
 Finally, create a detailed list of specific changes, including any relevant details or context, and be sure to focus on the most important and relevant changes while avoiding unnecessary or redundant information.
 
-If output json is true, output the result as json with fields for Title, Summary, and a list of Changes. Otherwise return the result as a string.
+Output the result as json with fields for Title, Summary, and a list of Changes. 
+For example, result:
+{"Title": "My Title", "Summary": "My Summary", "Changes": ["Change 1", "Change 2"]}
+Otherwise return the result as a string WITHOUT formatting it in JSON.
 
-output json: {{$outputJson}}
+OUTPUT_JSON: {{$outputJson}}
 
 Result:

--- a/skills/PRSkill/SemanticFunctions/PRSkill/PullRequestDescriptionGenerator/skprompt.txt
+++ b/skills/PRSkill/SemanticFunctions/PRSkill/PullRequestDescriptionGenerator/skprompt.txt
@@ -16,4 +16,8 @@ To complete this task, review the changes made in [GITDIFFCONTENT] and use this 
 Then, write a summary of the changes made, highlighting the key points and the most important changes.
 Finally, create a detailed list of specific changes, including any relevant details or context, and be sure to focus on the most important and relevant changes while avoiding unnecessary or redundant information.
 
+If output json is true, output the result as json with fields for Title, Summary, and a list of Changes. Otherwise return the result as a string.
+
+output json: {{$outputJson}}
+
 Result:

--- a/skills/PRSkill/Utils/FormatInstructionsProvider.cs
+++ b/skills/PRSkill/Utils/FormatInstructionsProvider.cs
@@ -1,0 +1,42 @@
+namespace PRSkill.Utils;
+public class FormatInstructionsProvider
+{
+    private const string OUTPUT_FORMAT_INSTRUCTIONS_JSON = @"
+Output the result as JSON with fields for Title, Summary, and a list of Changes. 
+For example, result:
+{""Title"": ""My Title"", ""Summary"": ""My Summary"", ""Changes"": [""Change 1"", ""Change 2""]}
+";
+
+    private const string OUTPUT_FORMAT_INSTRUCTIONS_TEXT = @"
+Output the result as plain text with the title, summary, and changes separated by newlines.
+";
+
+    private const string OUTPUT_FORMAT_INSTRUCTIONS_MARKDOWN = @"
+Output the result as markdown with the title, summary, and changes separated by newlines.
+For example, result:
+# My Title
+My Summary
+- Change 1
+- Change 2
+";
+
+    private static readonly Dictionary<string, string> _outputFormatInstructions = new()
+    {
+        { "json", OUTPUT_FORMAT_INSTRUCTIONS_JSON },
+        { "text", OUTPUT_FORMAT_INSTRUCTIONS_TEXT },
+        { string.Empty, OUTPUT_FORMAT_INSTRUCTIONS_TEXT },
+        { "markdown", OUTPUT_FORMAT_INSTRUCTIONS_MARKDOWN }
+    };
+
+    public static string GetOutputFormatInstructions(string outputFormat)
+    {
+        if (_outputFormatInstructions.TryGetValue(outputFormat, out string instructions))
+        {
+            return instructions;
+        }
+        else
+        {
+            throw new ArgumentException($"Unsupported output format: {outputFormat}");
+        }
+    }
+}


### PR DESCRIPTION
This adds an option to output as json or output to a file when generating a pull request description. This will let a github action parse the output when updating a PR description.
The following is what was output to a file from running the following command:
`dotnet run pr description --outputFile "out.txt " --outputFormat json`
out.txt:
```json
{
  "Title": "Update PRCommand, PullRequestSkill, and PullRequestDescriptionGenerator",
  "Summary": "This update modifies the PRCommand class, PullRequestSkill, and the PullRequestDescriptionGenerator to support outputting the result as JSON, markdown, or text. It also includes changes to the config.json and skprompt.txt files.",
  "Changes": [
    "Replace outputJsonOption with outputFormatOption in PRCommand.cs",
    "Update GeneratePRDescriptionCommand method to use outputFormatOption",
    "Modify RunPullRequestDescription method to accept outputFormat parameter",
    "Add using statements for System.Net.WebSockets and System.Text.Json.Nodes in PullRequestSkill.cs",
    "Update GeneratePullRequestDescription method to handle output format instructions",
    "Update output format instructions parameter in config.json",
    "Update skprompt.txt file to include instructions for outputting the result as JSON with fields for Title, Summary, and a list of Changes"
  ]
}
```