### PR TITLE
Use current git branch as the default + bugfix.

### DIFF
--- a/apps/SKonsole/ConfigurationProvider.cs
+++ b/apps/SKonsole/ConfigurationProvider.cs
@@ -31,7 +31,7 @@ public class ConfigurationProvider
     {
         var defaultConfig = new Dictionary<string, string>()
         {
-            { ConfigConstants.OPENAI_CHAT_MODEL_ID , "gpt-35-turbo" }
+            { ConfigConstants.OPENAI_CHAT_MODEL_ID , "gpt-3.5-turbo" }
         };
 
         bool hasChanged = false;


### PR DESCRIPTION
## Summary:

Changed the targetBranch to by default use the current. This is intended to allow me to use the command from my local branch without needing to retype it, mainly when the project default branch is not `main`.

Adjusted the git process to run actually where the command is requested (to allow debugging targetting other projects)

This PR also corrects a bug in the OpenAI Turbo default value.

## Changes:
- PRCommand.cs:
  - Modified the target branch option to accept a nullable string value.
  - Updated the default value for the target branch option.
  - Modified the RunPullRequestFeedback method to handle nullable target branch values.
  - Modified the RunPullRequestDescription method to handle nullable target branch values.
- ConfigurationProvider.cs:
  - Changed OPENAI_CHAT_MODEL_ID constant as the default model for OpenAI ChatGPT has a dot in the model.
  
Fixes: 
![image](https://github.com/lemillermicrosoft/skonsole/assets/19890735/2bee4964-c631-4f89-8f7b-a63c699cc7b1)
