### PR TITLE
🐛 Fix incorrect model ID in ConfigurationProvider

### DIFF
--- a/apps/SKonsole/ConfigurationProvider.cs
+++ b/apps/SKonsole/ConfigurationProvider.cs
@@ -31,14 +31,14 @@ public class ConfigurationProvider
     {
         var defaultConfig = new Dictionary<string, string>()
         {
-            { ConfigConstants.OPENAI_CHAT_MODEL_ID , "gpt-35-turbo" }
+            { ConfigConstants.OPENAI_CHAT_MODEL_ID , "gpt-3.5-turbo" }
         };
 
         bool hasChanged = false;
 
         foreach (var defaultConfigItem in defaultConfig)
         {
-            if (!string.IsNullOrWhiteSpace(this._configuration[defaultConfigItem.Key]))
+            if (!string.IsNullOrWhiteSpace(this._config[defaultConfigItem.Key]))
             {
                 this._config[defaultConfigItem.Key] = defaultConfigItem.Value;
                 hasChanged = true;


### PR DESCRIPTION
This commit fixes an incorrect model ID in the ConfigurationProvider class. The model ID has been updated from "gpt-35-turbo" to "gpt-3.5-turbo". Additionally, a variable reference has been corrected from "_configuration" to "_config" to ensure proper functionality.

Fixes #24 