### PR TITLE
Update Semantic.Kernel to beta 1.0 release - refactor and update SKonsole project, commands, and plugins

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,11 +10,9 @@
       "request": "launch",
       "preLaunchTask": "build",
       "program": "${workspaceFolder}/apps/SKonsole/bin/Debug/net7.0/SKonsole.dll",
-      "args": [
-        /*"commit"*/
-      ],
+      "args": ["stepwise", "optionset", "bing++"],
       "cwd": "${workspaceFolder}",
-      "console": "internalConsole",
+      "console": "integratedTerminal",
       "stopAtEntry": false
     },
     {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,41 +1,52 @@
 {
-    "version": "2.0.0",
-    "tasks": [
-        {
-            "label": "build",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "build",
-                "${workspaceFolder}/apps/SKonsole/SKonsole.csproj",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
-            ],
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "publish",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "publish",
-                "${workspaceFolder}/apps/SKonsole/SKonsole.csproj",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
-            ],
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "watch",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "watch",
-                "run",
-                "--project",
-                "${workspaceFolder}/apps/SKonsole/SKonsole.csproj"
-            ],
-            "problemMatcher": "$msCompile"
-        }
-    ]
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/apps/SKonsole/SKonsole.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "format",
+      "command": "dotnet",
+      "type": "process",
+      "args": ["format", "${workspaceFolder}/skonsole.sln"],
+      "problemMatcher": "$msCompile",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "publish",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "publish",
+        "${workspaceFolder}/apps/SKonsole/SKonsole.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "watch",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "run",
+        "--project",
+        "${workspaceFolder}/apps/SKonsole/SKonsole.csproj"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
 }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,10 +8,10 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageVersion Include="Microsoft.ML.Tokenizers" Version="0.21.0-preview.23266.6"/>
-    <PackageVersion Include="Microsoft.SemanticKernel" Version="0.24.230918.1-preview" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Skills.Web" Version="0.24.230918.1-preview" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Planning.StepwisePlanner" Version="0.24.230918.1-preview" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Reliability.Basic" Version="0.24.230918.1-preview" />
+    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.0.0-beta1" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Planners.Core" Version="1.0.0-beta1" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Plugins.Web" Version="1.0.0-beta1" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Reliability.Basic" Version="1.0.0-beta1" />
     <PackageVersion Include="Spectre.Console" Version="0.47.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="TextCopy" Version="6.2.1" />

--- a/apps/SKonsole/Commands/CommitCommand.cs
+++ b/apps/SKonsole/Commands/CommitCommand.cs
@@ -98,9 +98,9 @@ public class CommitCommand : Command
             }
         }
 
-        var pullRequestSkill = kernel.ImportSkill(new PRSkill.PullRequestSkill(kernel));
+        var pullRequestSkill = kernel.ImportFunctions(new PRSkill.PullRequestSkill(kernel));
 
-        void HorizontalRule(string title, string style = "white bold")
+        static void HorizontalRule(string title, string style = "white bold")
         {
             AnsiConsole.WriteLine();
             AnsiConsole.Write(new Rule($"[{style}]{title}[/]").RuleStyle("grey").LeftJustified());
@@ -121,7 +121,7 @@ public class CommitCommand : Command
                 var kernelResponse = await kernel.RunAsync(output, token, pullRequestSkill["GenerateCommitMessage"]);
                 task.StopTask();
 
-                var result = kernelResponse.Result;
+                var result = kernelResponse.GetValue<string>() ?? string.Empty;
                 await ClipboardService.SetTextAsync(result);
                 return result;
             });

--- a/apps/SKonsole/Commands/PRCommand.cs
+++ b/apps/SKonsole/Commands/PRCommand.cs
@@ -61,6 +61,7 @@ public class PRCommand : Command
     {
         return context.ParseResult.GetValueForOption(option);
     }
+
     private Command GeneratePRFeedbackCommand(Option<string> targetBranchOption)
     {
         var prFeedbackCommand = new Command("feedback", "Pull Request feedback subcommand");
@@ -106,11 +107,11 @@ public class PRCommand : Command
 
         string output = await process.StandardOutput.ReadToEndAsync();
 
-        var pullRequestSkill = kernel.ImportSkill(new PRSkill.PullRequestSkill(kernel));
+        var pullRequestSkill = kernel.ImportFunctions(new PRSkill.PullRequestSkill(kernel));
 
         var kernelResponse = await kernel.RunAsync(output, token, pullRequestSkill["GeneratePullRequestFeedback"]);
 
-        logger.LogInformation("Pull Request Feedback:\n{result}", kernelResponse.Result);
+        logger.LogInformation("Pull Request Feedback:\n{result}", kernelResponse.GetValue<string>());
     }
 
     private static async Task RunPullRequestDescription(CancellationToken token, ILogger logger, string targetBranch = "origin/main", string outputFormat = "", string outputFile = "", string diffInputFile = "")
@@ -119,13 +120,13 @@ public class PRCommand : Command
 
         var output = await FetchDiff(targetBranch, diffInputFile);
 
-        var pullRequestSkill = kernel.ImportSkill(new PRSkill.PullRequestSkill(kernel));
+        var pullRequestSkill = kernel.ImportFunctions(new PRSkill.PullRequestSkill(kernel));
 
         var contextVariables = new ContextVariables(output);
         contextVariables.Set("outputFormatInstructions", PRSkill.Utils.FormatInstructionsProvider.GetOutputFormatInstructions(outputFormat));
 
         var kernelResponse = await kernel.RunAsync(contextVariables, token, pullRequestSkill["GeneratePR"]);
-        logger.LogInformation("Pull Request Description:\n{result}", kernelResponse.Result);
+        logger.LogInformation("Pull Request Description:\n{result}", kernelResponse.GetValue<string>());
 
         if (!string.IsNullOrEmpty(outputFile))
         {
@@ -134,7 +135,7 @@ public class PRCommand : Command
             {
                 Directory.CreateDirectory(directory);
             }
-            System.IO.File.WriteAllText(outputFile, kernelResponse.Result);
+            System.IO.File.WriteAllText(outputFile, kernelResponse.GetValue<string>());
         }
     }
 

--- a/apps/SKonsole/Commands/PromptChatCommand.cs
+++ b/apps/SKonsole/Commands/PromptChatCommand.cs
@@ -2,9 +2,9 @@
 using System.Text;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.AI;
 using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.SemanticFunctions;
-using Microsoft.SemanticKernel.SkillDefinition;
 using SKonsole.Utils;
 using Spectre.Console;
 
@@ -46,16 +46,19 @@ public class PromptChatCommand : Command
     AI:
     ";
 
-        var promptConfig = new PromptTemplateConfig
-        {
-            Completion =
+        var promptConfig = new PromptTemplateConfig();
+        promptConfig.ModelSettings.Add(
+            new AIRequestSettings()
             {
-                MaxTokens = 2000,
-                Temperature = 0.7,
-                TopP = 0.5,
-                StopSequences = new List<string> { "Human:", "AI:" },
+                ExtensionData = new Dictionary<string, object>()
+                {
+                    { "Temperature", 0.7 },
+                    { "TopP", 0.5 },
+                    { "MaxTokens", 2000 },
+                    { "StopSequences", new List<string> { "Human:", "AI:" } }
+                }
             }
-        };
+        );
         var promptTemplate = new PromptTemplate(SkPrompt, promptConfig, kernel);
         var functionConfig = new SemanticFunctionConfig(promptConfig, promptTemplate);
         var chatFunction = kernel.RegisterSemanticFunction("PromptBot", "Chat", functionConfig);
@@ -74,7 +77,7 @@ public class PromptChatCommand : Command
         var botMessage = await kernel.RunAsync(contextVariables, chatFunction);
         var userMessage = string.Empty;
 
-        void HorizontalRule(string title, string style = "white bold")
+        static void HorizontalRule(string title, string style = "white bold")
         {
             AnsiConsole.WriteLine();
             AnsiConsole.Write(new Rule($"[{style}]{title}[/]").RuleStyle("grey").LeftJustified());
@@ -85,7 +88,7 @@ public class PromptChatCommand : Command
         {
             HorizontalRule("AI", "green bold");
             AnsiConsole.Foreground = ConsoleColor.Green;
-            AnsiConsole.WriteLine(botMessage.ToString());
+            AnsiConsole.WriteLine(botMessage?.ToString() ?? "NO MESSAGE FROM BOT");
             AnsiConsole.ResetColors();
 
             HorizontalRule("User");

--- a/apps/SKonsole/KernelProvider.cs
+++ b/apps/SKonsole/KernelProvider.cs
@@ -14,22 +14,16 @@ public class KernelProvider
     {
         var kernelBuilder = Kernel.Builder;
 
-        switch (Configuration.ConfigOption(ConfigConstants.LLM_PROVIDER))
+        kernelBuilder = Configuration.ConfigOption(ConfigConstants.LLM_PROVIDER) switch
         {
-            case ConfigConstants.OpenAI:
-                kernelBuilder = kernelBuilder.WithOpenAIChatCompletionService(
-                                       Configuration.ConfigVar(ConfigConstants.OPENAI_CHAT_MODEL_ID),
-                                       Configuration.ConfigVar(ConfigConstants.OPENAI_API_KEY));
-                break;
-            case ConfigConstants.AzureOpenAI:
-            default:
-                kernelBuilder = kernelBuilder.WithAzureChatCompletionService(
-                                       Configuration.ConfigVar(ConfigConstants.AZURE_OPENAI_CHAT_DEPLOYMENT_NAME),
-                                       Configuration.ConfigVar(ConfigConstants.AZURE_OPENAI_API_ENDPOINT),
-                                       Configuration.ConfigVar(ConfigConstants.AZURE_OPENAI_API_KEY));
-                break;
-        }
-
+            ConfigConstants.OpenAI => kernelBuilder.WithOpenAIChatCompletionService(
+                                                   Configuration.ConfigVar(ConfigConstants.OPENAI_CHAT_MODEL_ID),
+                                                   Configuration.ConfigVar(ConfigConstants.OPENAI_API_KEY)),
+            _ => kernelBuilder.WithAzureChatCompletionService(
+                                                   Configuration.ConfigVar(ConfigConstants.AZURE_OPENAI_CHAT_DEPLOYMENT_NAME),
+                                                   Configuration.ConfigVar(ConfigConstants.AZURE_OPENAI_API_ENDPOINT),
+                                                   Configuration.ConfigVar(ConfigConstants.AZURE_OPENAI_API_KEY)),
+        };
         var _kernel = kernelBuilder
             .WithRetryBasic(new()
             {

--- a/apps/SKonsole/Program.cs
+++ b/apps/SKonsole/Program.cs
@@ -6,13 +6,14 @@ using SKonsole.Commands;
 
 Console.OutputEncoding = Encoding.Unicode;
 
-var rootCommand = new RootCommand();
-
-rootCommand.Add(new ConfigCommand(ConfigurationProvider.Instance));
-rootCommand.Add(new CommitCommand(ConfigurationProvider.Instance));
-rootCommand.Add(new PRCommand(ConfigurationProvider.Instance));
-rootCommand.Add(new PlannerCommand(ConfigurationProvider.Instance));
-rootCommand.Add(new StepwisePlannerCommand(ConfigurationProvider.Instance));
-rootCommand.Add(new PromptChatCommand(ConfigurationProvider.Instance));
+var rootCommand = new RootCommand
+{
+    new ConfigCommand(ConfigurationProvider.Instance),
+    new CommitCommand(ConfigurationProvider.Instance),
+    new PRCommand(ConfigurationProvider.Instance),
+    new PlannerCommand(ConfigurationProvider.Instance),
+    new StepwisePlannerCommand(ConfigurationProvider.Instance),
+    new PromptChatCommand(ConfigurationProvider.Instance)
+};
 
 return await rootCommand.InvokeAsync(args);

--- a/apps/SKonsole/SKonsole.csproj
+++ b/apps/SKonsole/SKonsole.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Microsoft.SemanticKernel"/>
-    <PackageReference Include="Microsoft.SemanticKernel.Skills.Web"/>
-    <PackageReference Include="Microsoft.SemanticKernel.Planning.StepwisePlanner"/>
+    <PackageReference Include="Microsoft.SemanticKernel.Planners.Core"/>
+    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Web"/>
     <PackageReference Include="Microsoft.SemanticKernel.Reliability.Basic"/>
     <PackageReference Include="Spectre.Console"/>
     <PackageReference Include="System.CommandLine"  />

--- a/apps/SKonsole/Skills/EmailSkill.cs
+++ b/apps/SKonsole/Skills/EmailSkill.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel;
 using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Orchestration;
-using Microsoft.SemanticKernel.SkillDefinition;
 
 namespace SKonsole.Skills;
 

--- a/apps/SKonsole/Skills/GitSkill.cs
+++ b/apps/SKonsole/Skills/GitSkill.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Diagnostics;
+using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Orchestration;
-using Microsoft.SemanticKernel.SkillDefinition;
 
 namespace SKonsole.Skills;
 

--- a/apps/SKonsole/Skills/SuperFileIOPlugin.cs
+++ b/apps/SKonsole/Skills/SuperFileIOPlugin.cs
@@ -1,0 +1,89 @@
+﻿
+using System.ComponentModel;
+using System.Text;
+using Microsoft.SemanticKernel;
+
+namespace SKonsole.Skills;
+
+public class SuperFileIOPlugin
+{
+    /// <summary>
+    /// Read a file
+    /// </summary>
+    /// <example>
+    /// {{file.readAsync $path }} => "hello world"
+    /// </example>
+    /// <param name="path"> Source file </param>
+    /// <returns> File content </returns>
+    [SKFunction, Description("Read a file")]
+    public async Task<string> ReadAsync([Description("Source file")] string path)
+    {
+        path = string.IsNullOrEmpty(path) ? Directory.GetCurrentDirectory() : path;
+        using var reader = File.OpenText(path);
+        return await reader.ReadToEndAsync().ConfigureAwait(false);
+    }
+
+    [SKFunction, Description("List files in a directory")]
+    public string List([Description("Source directory")] string path)
+    {
+        path = string.IsNullOrEmpty(path) ? Directory.GetCurrentDirectory() : path;
+        var files = Directory.GetFiles(path);
+        return string.Join("\n", files);
+    }
+
+    [SKFunction, Description("List directories in a directory")]
+    public string ListDirs([Description("Source directory")] string path)
+    {
+        path = string.IsNullOrEmpty(path) ? Directory.GetCurrentDirectory() : path;
+        var files = Directory.GetFiles(path);
+        return string.Join("\n", files);
+    }
+
+    [SKFunction, Description("Search files in a directory")]
+    public string Search([Description("Source directory")] string path, [Description("Search pattern")] string pattern)
+    {
+        path = string.IsNullOrEmpty(path) ? Directory.GetCurrentDirectory() : path;
+        var files = Directory.GetFiles(path, pattern);
+        return string.Join("\n", files);
+    }
+
+    [SKFunction, Description("Search files in a directory, recursively")]
+    public string SearchAll([Description("Source directory")] string path, [Description("Search pattern")] string pattern)
+    {
+        path = string.IsNullOrEmpty(path) ? Directory.GetCurrentDirectory() : path;
+        var files = Directory.GetFiles(path, pattern, SearchOption.AllDirectories);
+        return string.Join("\n", files);
+    }
+
+    [SKFunction, Description("Get current directory")]
+    public string CurrentDirectory()
+    {
+        return Directory.GetCurrentDirectory();
+    }
+
+    /// <summary>
+    /// Write a file
+    /// </summary>
+    /// <example>
+    /// {{file.writeAsync}}
+    /// </example>
+    /// <param name="path">The destination file path</param>
+    /// <param name="content">The file content to write</param>
+    /// <returns> An awaitable task </returns>
+    [SKFunction, Description("Write a file")]
+    public async Task WriteAsync(
+        [Description("Destination file")] string path,
+        [Description("File content")] string content)
+    {
+        path = string.IsNullOrEmpty(path) ? Directory.GetCurrentDirectory() : path;
+        byte[] text = Encoding.UTF8.GetBytes(content);
+        if (File.Exists(path) && File.GetAttributes(path).HasFlag(FileAttributes.ReadOnly))
+        {
+            // Most environments will throw this with OpenWrite, but running inside docker on Linux will not.
+            throw new UnauthorizedAccessException($"File is read-only: {path}");
+        }
+
+        using var writer = File.OpenWrite(path);
+        await writer.WriteAsync(text, 0, text.Length).ConfigureAwait(false);
+    }
+}

--- a/apps/SKonsole/Skills/WriterSkill.cs
+++ b/apps/SKonsole/Skills/WriterSkill.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.SkillDefinition;
+using Microsoft.SemanticKernel.AI;
 
 namespace SKonsole.Skills;
 
@@ -13,11 +13,17 @@ internal sealed class WriterSkill
     {
         this._funnyPoemFunction = kernel.CreateSemanticFunction(
             FunnyPoemDefinition,
-            skillName: nameof(WriterSkill),
+            pluginName: nameof(WriterSkill),
             description: "Given a input topic or description or list, write a funny poem.",
-            maxTokens: MaxTokens,
-            temperature: 0.1,
-            topP: 0.5);
+            requestSettings: new AIRequestSettings()
+            {
+                ExtensionData = new Dictionary<string, object>()
+                {
+                    { "Temperature", 0.1 },
+                    { "TopP", 0.5 },
+                    { "MaxTokens", MaxTokens }
+                }
+            });
     }
 
     private const string FunnyPoemDefinition =

--- a/apps/SKonsole/Utils/Logging.cs
+++ b/apps/SKonsole/Utils/Logging.cs
@@ -10,11 +10,12 @@ internal static class Logging
             {
                 builder
                     .SetMinimumLevel(LogLevel.Information)
+                    // .AddFilter("Microsoft.SemanticKernel.Planners.StepwisePlanner", LogLevel.Information) // Toggle to see chain of thought
                     .AddFilter("Microsoft", LogLevel.Error)
                     .AddFilter("AzureChatCompletion", LogLevel.Error)
                     .AddFilter("System", LogLevel.Error)
                     .AddFilter("SKonsole", LogLevel.Information)
-                    .AddConsole();
+                    .AddSpectreConsole();
             });
     }
 }

--- a/apps/SKonsole/Utils/SpectreConsoleExtensions.cs
+++ b/apps/SKonsole/Utils/SpectreConsoleExtensions.cs
@@ -7,7 +7,7 @@ internal static class SpectreConsoleExtensions
     {
         if (obj == null)
         {
-            throw new ArgumentNullException("obj");
+            throw new ArgumentNullException(nameof(obj));
         }
 
         obj.IsSecret = IsSecret;

--- a/apps/SKonsole/Utils/SpectreConsoleLoggerProvider.cs
+++ b/apps/SKonsole/Utils/SpectreConsoleLoggerProvider.cs
@@ -1,0 +1,94 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+
+namespace SKonsole.Utils;
+
+public sealed class SpectreConsoleLoggerProvider : ILoggerProvider
+{
+    public ILogger CreateLogger(string categoryName)
+    {
+        return new SpectreConsoleLogger(categoryName);
+    }
+
+    public void Dispose() { }
+}
+
+public sealed class SpectreConsoleLogger : ILogger, IDisposable
+{
+    private readonly string _categoryName;
+
+    public SpectreConsoleLogger(string categoryName)
+    {
+        this._categoryName = categoryName;
+    }
+
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull => this;
+
+    public void Dispose()
+    {
+        return;
+    }
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        if (!this.IsEnabled(logLevel))
+        {
+            return;
+        }
+
+        var message = formatter(state, exception);
+
+        if (this._categoryName.EndsWith(".StepwisePlanner"))
+        {
+            var splitIndex = message.IndexOf(':');
+            if (splitIndex == -1)
+            {
+                AnsiConsole.MarkupLineInterpolated($"[bold red]{message}[/]");
+                return;
+            }
+
+            var label = message.Substring(0, splitIndex);
+            var rest = message.Substring(splitIndex + 1);
+
+            if (label == "Action")
+            {
+                if (rest.Contains("No action to take"))
+                {
+                    return;
+                }
+
+                AnsiConsole.MarkupLineInterpolated($"[bold blue]{label}:[/] {rest}");
+                return;
+            }
+
+            // if final answer, color is green
+            if (label == "Thought" && rest.StartsWith("Final answer:"))
+            {
+                AnsiConsole.MarkupLineInterpolated($"[bold green]{label}:[/] {rest}");
+                return;
+            }
+
+            AnsiConsole.MarkupLineInterpolated($"[bold yellow]{label}:[/] {rest}");
+            return;
+        }
+
+        AnsiConsole.MarkupLineInterpolated($"[bold]{logLevel}[/]: {this._categoryName}: {message}");
+    }
+}
+
+public static class SpectreConsoleLoggingExtensions
+{
+    public static ILoggingBuilder AddSpectreConsole(this ILoggingBuilder builder)
+    {
+        builder.Services.AddSingleton<ILoggerProvider, SpectreConsoleLoggerProvider>();
+        return builder;
+    }
+}

--- a/skills/PRSkill/Utils/CommitParser.cs
+++ b/skills/PRSkill/Utils/CommitParser.cs
@@ -47,7 +47,7 @@ internal static class StringEx
             }
 
             var fileDiffMetadata = fileDiffMatch.Value;
-            var nextMatch = j == fileDiffMatches.Count - 1 || (fileDiffMatches[j + 1].Index) >= inputEnd ? inputEnd : fileDiffMatches[j + 1].Index;
+            var nextMatch = j == fileDiffMatches.Count - 1 || fileDiffMatches[j + 1].Index >= inputEnd ? inputEnd : fileDiffMatches[j + 1].Index;
             var fileDiff = input[(fileDiffMatch.Index + fileDiffMatch.Length)..nextMatch];
             fileDiffChunks.Add((fileDiffMetadata, fileDiff));
         }


### PR DESCRIPTION
## Summary
This pull request includes a comprehensive update to the SKonsole project, refactoring and updating commands, plugins, and dependencies. The changes aim to enhance code readability, maintainability, and improve logging output.

## Changes
- Changed launch arguments in .vscode/launch.json to include 'stepwise', 'optionset', and 'bing++'
- Changed console setting in .vscode/launch.json from 'internalConsole' to 'integratedTerminal'
- Added a new 'format' task in .vscode/tasks.json
- Updated package versions in Directory.Packages.props for Microsoft.SemanticKernel and related packages
- Replaced kernel.ImportSkill with kernel.ImportFunctions in CommitCommand.cs and PRCommand.cs
- Updated kernelResponse.Result to kernelResponse.GetValue<string>() in CommitCommand.cs and PRCommand.cs
- Update PRCommand to use GetValue<string>() instead of Result for kernelResponse
- Refactor PlannerCommand to use new naming conventions and structure for SemanticKernel library
- Update PromptChatCommand to use new AIRequestSettings and PromptTemplateConfig structure
- Refactor StepwisePlannerCommand to use new naming conventions and structure for SemanticKernel library
- Rename 'WebSearchEngineSkill' to 'WebSearchEnginePlugin' and update its usage in the code
- Rename 'TimeSkill' to 'TimePlugin' and update its usage in the code
- Rename 'ConversationSummarySkill' to 'ConversationSummaryPlugin' and update its usage in the code
- Rename 'FileIOSkill' to 'SuperFileIOPlugin' and update its usage in the code
- Update the 'RespondTo' function to return 'SKContext?' instead of 'SKContext'
- Refactor the 'RespondTo' function to extract metadata and result string into a new SKContext
- Update the 'RunChat' function to handle the new 'RespondTo' function return type and display additional information when 'Result not found'
- Refactor the 'KernelProvider' to use a switch expression for configuring the LLM provider
- Refactor KernelProvider.cs to include new configuration options for OpenAI and Azure chat completion services
- Refactor Program.cs to use a more concise syntax for adding commands to the root command
- Update SKonsole.csproj to replace Microsoft.SemanticKernel.Skills.Web and Microsoft.SemanticKernel.Planning.StepwisePlanner with Microsoft.SemanticKernel.Planners.Core and Microsoft.SemanticKernel.Plugins.Web
- Update EmailSkill.cs and GitSkill.cs to use the new Microsoft.SemanticKernel namespace instead of Microsoft.SemanticKernel.SkillDefinition
- Add a new SuperFileIOPlugin.cs for file operations, including reading, writing, listing, and searching files and directories
- Update WriterSkill.cs to use the new Microsoft.SemanticKernel.AI namespace
- Changed 'skillName' to 'pluginName' in WriterSkill.cs
- Updated AIRequestSettings in WriterSkill.cs to use a dictionary for extension data
- Added SpectreConsoleExtensions.cs to handle secret input prompts
- Replaced ArgumentNullException with nameof(obj) in SpectreConsoleExtensions.cs
- Created a new SpectreConsoleLoggerProvider in SpectreConsoleLoggerProvider.cs
- Implemented SpectreConsoleLoggingExtensions for adding SpectreConsole to the logging builder
- Modified Logging.cs to use the new SpectreConsoleLoggerProvider
- Updated CondenseSkill.cs to use the new semantic function import method
- Changed function invocation in CondenseSkill.cs to use the new Runner.RunAsync method
- Replace `func.InvokeAsync` with `context.Runner.RunAsync` for better readability
- Rename `ImportSemanticSkillFromDirectory` to `ImportSemanticFunctionsFromDirectory` to better reflect its purpose
- Update method signatures for `ITextCompletion.GetCompletionsAsync` and `ITextCompletion.GetStreamingCompletionsAsync` to use `AIRequestSettings` instead of `CompleteRequestSettings`
- Modify the calculation of `nextMatch` in `SplitFileInfo` method for better readability
- Replace `context.Skills.GetFunction` with `context.Functions.GetFunction` to better align with the updated method names

---
*Powered by [Microsoft Semantic Kernel](https://github.com/microsoft/semantic-kernel)*