### PR TITLE
Fix potential null value issue in MergeDefaultConfig

### DIFF
--- a/apps/SKonsole/ConfigurationProvider.cs
+++ b/apps/SKonsole/ConfigurationProvider.cs
@@ -35,13 +35,15 @@ public class ConfigurationProvider
         };
 
         bool hasChanged = false;
-
         foreach (var defaultConfigItem in defaultConfig)
         {
-            if (string.IsNullOrWhiteSpace(this._config[defaultConfigItem.Key]))
+            if (this._config.TryGetValue(defaultConfigItem.Key, out string? value))
             {
-                this._config[defaultConfigItem.Key] = defaultConfigItem.Value;
-                hasChanged = true;
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    this._config[defaultConfigItem.Key] = defaultConfigItem.Value;
+                    hasChanged = true;
+                }
             }
         }
 

--- a/apps/SKonsole/ConfigurationProvider.cs
+++ b/apps/SKonsole/ConfigurationProvider.cs
@@ -37,13 +37,10 @@ public class ConfigurationProvider
         bool hasChanged = false;
         foreach (var defaultConfigItem in defaultConfig)
         {
-            if (this._config.TryGetValue(defaultConfigItem.Key, out string? value))
+            if (!this._config.TryGetValue(defaultConfigItem.Key, out string? value) || string.IsNullOrWhiteSpace(value))
             {
-                if (string.IsNullOrWhiteSpace(value))
-                {
-                    this._config[defaultConfigItem.Key] = defaultConfigItem.Value;
-                    hasChanged = true;
-                }
+                this._config[defaultConfigItem.Key] = defaultConfigItem.Value;
+                hasChanged = true;
             }
         }
 


### PR DESCRIPTION
I installed SKonsole using the following command
```bash
dotnet tool install --global SKonsole
```
However, when I attempted to check the SKonsole version using `skonsole --version`, I encountered an issue. The error message I received is as follows:
```powershell
PS D:\Project> skonsole --version
Unhandled exception. System.TypeInitializationException: The type initializer for 'SKonsole.ConfigurationProvider' threw an exception.
 ---> System.Collections.Generic.KeyNotFoundException: The given key 'OPENAI_CHAT_MODEL_ID' was not present in the dictionary.
   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at SKonsole.ConfigurationProvider.MergeDefaultConfig() in D:\repos\skonsole\apps\SKonsole\ConfigurationProvider.cs:line 41
   at SKonsole.ConfigurationProvider..ctor() in D:\repos\skonsole\apps\SKonsole\ConfigurationProvider.cs:line 27
   at SKonsole.ConfigurationProvider..cctor() in D:\repos\skonsole\apps\SKonsole\ConfigurationProvider.cs:line 9
   --- End of inner exception stack trace ---
   at Program.<Main>$(String[] args) in D:\repos\skonsole\apps\SKonsole\Program.cs:line 9
   at Program.<Main>(String[] args)
```
To resolve this issue, I cloned the source code, identified the problem, and implemented the necessary fix. 
After making the fix, SKonsole worked perfectly.