### PR TITLE
✨ Add ExecuteCommand to SKonsole

### DIFF
--- a/apps/SKonsole/Commands/ExecuteCommand.cs
+++ b/apps/SKonsole/Commands/ExecuteCommand.cs
@@ -33,9 +33,8 @@ internal sealed class ExecuteCommand : Command
         this.AddOption(templateOption);
 
         var outputOption = new Option<string>(
-                          new string[] { "--output", "-o" },
-                          () => { return ""; },
-                          "Output the result to the specified file.");
+                          new string[] { "--outputFile", "-o" },
+                          description: "Output the result to the specified file.");
         this.AddOption(outputOption);
 
         this.SetHandler(async context => await RunExecuteAsync(context.GetCancellationToken(),

--- a/apps/SKonsole/Commands/ExecuteCommand.cs
+++ b/apps/SKonsole/Commands/ExecuteCommand.cs
@@ -8,7 +8,7 @@ internal sealed class ExecuteCommand : Command
 {
     private ILogger _logger;
 
-    public ExecuteCommand(ConfigurationProvider config, ILogger? logger = null) : base("exec", "Execute semantic function directly.")
+    public ExecuteCommand(ConfigurationProvider config, ILogger? logger = null) : base("exec", "Execute semantic function.")
     {
         if (logger is null)
         {
@@ -21,7 +21,7 @@ internal sealed class ExecuteCommand : Command
         }
 
         var promptArgument = new Argument<string>
-            ("prompt", "An argument that is parsed as a string.");
+            ("prompt", "The semantic function prompt or input for direct execution");
 
         this.AddArgument(promptArgument);
 
@@ -34,7 +34,7 @@ internal sealed class ExecuteCommand : Command
 
         var outputOption = new Option<string>(
                           new string[] { "--output", "-o" },
-                          () => { return "{{$output}}"; },
+                          () => { return ""; },
                           "Output the result to the specified file.");
         this.AddOption(outputOption);
 

--- a/apps/SKonsole/Commands/ExecuteCommand.cs
+++ b/apps/SKonsole/Commands/ExecuteCommand.cs
@@ -56,6 +56,9 @@ internal sealed class ExecuteCommand : Command
 
         var result = output.GetValue<string>();
 
-        Console.WriteLine(result);
+        using var streamWriter = new StreamWriter(Console.OpenStandardOutput());
+        streamWriter.AutoFlush = true;
+        Console.SetOut(streamWriter);
+        Console.Write(result);
     }
 }

--- a/apps/SKonsole/Commands/ExecuteCommand.cs
+++ b/apps/SKonsole/Commands/ExecuteCommand.cs
@@ -1,0 +1,61 @@
+﻿using System.CommandLine;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel;
+using SKonsole.Utils;
+
+namespace SKonsole.Commands;
+internal sealed class ExecuteCommand : Command
+{
+    private ILogger _logger;
+
+    public ExecuteCommand(ConfigurationProvider config, ILogger? logger = null) : base("exec", "Execute semantic function directly.")
+    {
+        if (logger is null)
+        {
+            using var loggerFactory = Logging.GetFactory();
+            this._logger = loggerFactory.CreateLogger(this.GetType());
+        }
+        else
+        {
+            this._logger = logger;
+        }
+
+        var promptArgument = new Argument<string>
+            ("prompt", "An argument that is parsed as a string.");
+
+        this.AddArgument(promptArgument);
+
+        var templateOption = new Option<string>(
+                            new string[] { "--template", "-t" },
+                            () => { return "{{$input}}"; },
+                           "The template to use for the semantic function.");
+
+        this.AddOption(templateOption);
+
+        this.SetHandler(async context => await RunExecuteAsync(context.GetCancellationToken(),
+            context.BindingContext.ParseResult.GetValueForArgument<string>(promptArgument),
+            context.BindingContext.ParseResult.GetValueForOption<string>(templateOption),
+            this._logger));
+    }
+
+    private static async Task RunExecuteAsync(CancellationToken cancellationToken,
+        string prompt,
+        string? template = null,
+        ILogger? logger = null)
+    {
+        var kernel = KernelProvider.Instance.Get();
+
+        if (string.IsNullOrWhiteSpace(template))
+        {
+            template = "{{$input}}";
+        }
+
+        var func = kernel.CreateSemanticFunction(template);
+
+        var output = await kernel.RunAsync(prompt, func);
+
+        var result = output.GetValue<string>();
+
+        Console.WriteLine(result);
+    }
+}

--- a/apps/SKonsole/Program.cs
+++ b/apps/SKonsole/Program.cs
@@ -13,7 +13,8 @@ var rootCommand = new RootCommand(description: "SKonsole is a powerful command-l
     new PRCommand(ConfigurationProvider.Instance),
     new PlannerCommand(ConfigurationProvider.Instance),
     new StepwisePlannerCommand(ConfigurationProvider.Instance),
-    new PromptChatCommand(ConfigurationProvider.Instance)
+    new PromptChatCommand(ConfigurationProvider.Instance),
+    new ExecuteCommand(ConfigurationProvider.Instance),
 };
 
 return await rootCommand.InvokeAsync(args);


### PR DESCRIPTION
Add a new command called ExecuteCommand to SKonsole. This command allows users to execute semantic functions directly. The command takes a prompt argument and an optional template option. The template option specifies the template to use for the semantic function, with a default value of "{{$input}}". The command uses the KernelProvider to get an instance of the semantic kernel and creates a semantic function based on the template. It then runs the semantic function with the provided prompt and outputs the result. The result is printed to the console.

```
Description:
  Execute semantic function.

Usage:
  SKonsole exec <prompt> [options]

Arguments:
  <prompt>  The semantic function prompt or input for direct execution

Options:
  -t, --template <template>      The template (file) to use for the semantic function. [default: {{$input}}]
  -o, --outputFile <outputFile>  Output the result to the specified file.
  -?, -h, --help                 Show help and usage information
```

example:
```sh
skonsole exec  "prompt input" -t "template or template file (optional)" -o output.txt(optional)
```

